### PR TITLE
Update Header class to not expand

### DIFF
--- a/Container.py
+++ b/Container.py
@@ -15,6 +15,7 @@ class Header(QtWidgets.QWidget):
         self.content = content_widget
         self.expand_ico = QtGui.QPixmap(":teDownArrow.png")
         self.collapse_ico = QtGui.QPixmap(":teRightArrow.png")
+        self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
 
         stacked = QtWidgets.QStackedLayout(self)
         stacked.setStackingMode(QtWidgets.QStackedLayout.StackAll)


### PR DESCRIPTION
Added a size policy in the header so it doesn't expand and does not need the extra code at the end

```
layout.addItem(QtWidgets.QSpacerItem(0, 0, QtWidgets.QSizePolicy.Expanding)) 
layout.setStretch(1, 1)
```

example:

```
import sys
from PySide2 import QtGui, QtWidgets
import Container

# Create main application window
if not QtWidgets.QApplication.instance():
    app = QtWidgets.QApplication(sys.argv)
else:
    app = QtWidgets.QApplication.instance()
        
wid = QtWidgets.QWidget()
wid.resize(250, 150)
wid.setWindowTitle('Simple')

layout = QtWidgets.QVBoxLayout(wid)
container = Container("Group")
layout.addWidget(container)

content_layout = QtWidgets.QGridLayout(container.contentWidget) content_layout.addWidget(QtWidgets.QPushButton("Button"))


wid.show()
```